### PR TITLE
Adding an endpoint for case comment range queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/bower_components
 *.iml
 .idea

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "udsjs",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "Javascript library to interact with Unified Data Services",
   "main": "uds.js",
   "repository": {

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,6 @@
   ],
   "dependencies": {
     "jquery": ">=1.7.2",
-    "jsUri": "~1.2.1"
+    "jsuri": "~1.3.1"
   }
 }

--- a/test/js/uds-driver.js
+++ b/test/js/uds-driver.js
@@ -35,7 +35,7 @@ require(['uds'], function (uds) {
         console.debug("Successfully fetched case comments " + comments.length)
     }, errorFunc);
     
-    uds.makeUqlQuery('/case/comments', 'ownerId is "005A0000000zqMTIAY" AND (lastModifiedDate >= 2016-05-01 AND lastModifiedDate <= 2016-05-03)').then(function(comments) {
+    uds.fetchComments('ownerId is "005A0000000zqMTIAY" AND (lastModifiedDate >= 2016-05-01 AND lastModifiedDate <= 2016-05-03)').then(function(comments) {
         console.debug("Fetched " + comments.length + " comments via UQL and a date range.")
     }, errorFunc);
 

--- a/test/js/uds-driver.js
+++ b/test/js/uds-driver.js
@@ -12,35 +12,57 @@ require.config({
 });
 require(['uds'], function (uds) {
 
+    Promise.longStackTraces = true;
+
     'use strict';
+    var errorFunc = function(error) {
+        console.debug(error.statusText + "\n" + error.responseText);
+    };
 
+    uds.getSbrList('Minimal', 'sbrName like "%"').then(function(sbrs) {
+        console.debug("Successfully fetched " + sbrs.length + " sbrs.");
+    }, errorFunc);
 
+    uds.fetchCaseDetails("1332755").then(function(kase) {
+        console.debug("Successfully fetched case details for case: " + kase.resource.caseNumber);
+    }, errorFunc);
 
-    uds.fetchCaseDetails(
-        "1332755"
-    );
+    uds.fetchCaseDetails("1332755").then(function(kase) {
+        console.debug("Successfully fetched case details for case: " + kase.resource.caseNumber);
+    }, errorFunc);
 
-    uds.fetchCaseComments(
-        "01278378"
-    );
+    uds.fetchCaseComments("01278378").then(function(comments) {
+        console.debug("Successfully fetched case comments " + comments.length)
+    }, errorFunc);
+    
+    uds.makeUqlQuery('/case/comments', 'ownerId is "005A0000000zqMTIAY" AND (lastModifiedDate >= 2016-05-01 AND lastModifiedDate <= 2016-05-03)').then(function(comments) {
+        console.debug("Fetched " + comments.length + " comments via UQL and a date range.")
+    }, errorFunc);
 
-    uds.fetchUserDetails(
-        "rhn-support-rmanes"
-    );
-    uds.fetchUser(
-        "SSO is \"rhn-support-rmanes\""
-    );
-    uds.fetchCases(        //sample query for getting owned cases based on roles
-
+    uds.fetchUserDetails("rhn-support-rmanes").then(function(user) {
+        console.debug("Fetched user details for: " + user[0].externalModelId)
+    }, errorFunc);
+    uds.fetchUser('SSO is "rhn-support-rmanes"').then(function(user) {
+        console.debug("Fetched user: " + user[0].externalModelId)
+    }, errorFunc);
+    
+    //sample query for getting owned cases based on roles 
+    uds.fetchCases(        
         '((((((ownerId is "005A0000000gPRIIA2" and (status is "Waiting on Red Hat" or internalStatus is "Waiting on Owner")) or (ftsRole like "%strataapi2%" and status ne "Closed"))) or ((internalStatus is "Waiting on Collaboration" and (status ne "Closed")) and nnoSuperRegion is null)) or (isFTS is true and (ftsRole is ""))) and requiresSecureHandling is false)',
         'Minimal',
         6
-    );
+    ).then(function(cases) {
+        console.debug("Fetched " + cases.length + " cases");
+    }, errorFunc);
     uds.updateCaseDetails(
         '01278378',
         '{"resource":{"caseSummary":{"resource":{"summary":"test"}}}}'
-    );
-    uds.fetchCaseAssociateDetails(
-        '005A0000005n18tIAA','Contributor'
-    )
+    ).then(function() {
+        console.debug("Updated case.");
+    }, errorFunc);
+    
+    // Unclear right now what the UQL for this one is
+    // uds.fetchCaseAssociateDetails('005A0000005n18tIAA').then(function() {
+    //    
+    // }, errorFunc)
 });

--- a/uds.js
+++ b/uds.js
@@ -445,10 +445,5 @@
         return executeUdsAjaxCall(url, 'GET');
     };
     
-    uds.makeUqlQuery = function (path, uql) {
-        var url = udsHostName.clone().setPath(path).addQueryParam('where', uql);
-        return executeUdsAjaxCall(url, 'GET');
-    };
-
     return uds;
 }));

--- a/uds.js
+++ b/uds.js
@@ -5,11 +5,11 @@
 (function (root, factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
-        define('uds', ['jquery', 'jsUri','bluebird'], factory);
+        define('uds', ['jquery', 'jsUri', 'bluebird'], factory);
     } else {
-        root.uds = factory(root.$, root.Uri,root.Promise);
+        root.uds = factory(root.$, root.Uri, root.Promise);
     }
-}(this, function ($, Uri,Promise) {
+}(this, function ($, Uri, Promise) {
     'use strict';
 
     var uds = {};
@@ -17,29 +17,26 @@
     var udsHostName = new Uri('https://unified-ds-ci.gsslab.brq.redhat.com/');
 
 
-    if (window.location.hostname === 'access.redhat.com' || window.location.hostname === 'prod.foo.redhat.com' || window.location.hostname === 'fooprod.redhat.com'){
+    if (window.location.hostname === 'access.redhat.com' || window.location.hostname === 'prod.foo.redhat.com' || window.location.hostname === 'fooprod.redhat.com') {
         udsHostName = new Uri('https://unified-ds.gsslab.rdu2.redhat.com/');
     }
-    else
-    {
-      if (window.location.hostname === 'access.qa.redhat.com' || window.location.hostname === 'qa.foo.redhat.com' || window.location.hostname === 'fooqa.redhat.com') {
-          udsHostName = new Uri('https://unified-ds-qa.gsslab.pnq2.redhat.com/');
-      }
-      else
-      {
-         if (window.location.hostname === 'access.devgssci.devlab.phx1.redhat.com' || window.location.hostname === 'ci.foo.redhat.com' || window.location.hostname === 'fooci.redhat.com') {
+    else {
+        if (window.location.hostname === 'access.qa.redhat.com' || window.location.hostname === 'qa.foo.redhat.com' || window.location.hostname === 'fooqa.redhat.com') {
+            udsHostName = new Uri('https://unified-ds-qa.gsslab.pnq2.redhat.com/');
+        }
+        else {
+            if (window.location.hostname === 'access.devgssci.devlab.phx1.redhat.com' || window.location.hostname === 'ci.foo.redhat.com' || window.location.hostname === 'fooci.redhat.com') {
                 udsHostName = new Uri('https://unified-ds-ci.gsslab.brq.redhat.com/');
-         }
-         else
-               {
-                  if (window.location.hostname === 'access.stage.redhat.com' || window.location.hostname === 'stage.foo.redhat.com' || window.location.hostname === 'foostage.redhat.com') {
-                         udsHostName = new Uri('https://unified-ds-stage.gsslab.pnq2.redhat.com/');
-                  }
-               }
-      }
+            }
+            else {
+                if (window.location.hostname === 'access.stage.redhat.com' || window.location.hostname === 'stage.foo.redhat.com' || window.location.hostname === 'foostage.redhat.com') {
+                    udsHostName = new Uri('https://unified-ds-stage.gsslab.pnq2.redhat.com/');
+                }
+            }
+        }
     }
 
-    if(localStorage && localStorage.getItem('udsHostname')) {
+    if (localStorage && localStorage.getItem('udsHostname')) {
         udsHostName = localStorage.getItem('udsHostname');
     }
 
@@ -64,9 +61,8 @@
         dataType: ''
     };
 
-    var executeUdsAjaxCall=function(url,httpMethod)
-    {
-        var promise=Promise.resolve($.ajax($.extend({}, baseAjaxParams,{
+    var executeUdsAjaxCall = function (url, httpMethod) {
+        var promise = Promise.resolve($.ajax($.extend({}, baseAjaxParams, {
             url: url,
             type: httpMethod,
             method: httpMethod
@@ -74,9 +70,8 @@
         return promise;
     };
 
-    var executeUdsAjaxCallWithData=function(url,data,httpMethod)
-    {
-        var promise=Promise.resolve($.ajax($.extend({}, baseAjaxParams,{
+    var executeUdsAjaxCallWithData = function (url, data, httpMethod) {
+        var promise = Promise.resolve($.ajax($.extend({}, baseAjaxParams, {
             url: url,
             data: JSON.stringify(data),
             contentType: 'application/json',
@@ -89,64 +84,69 @@
 
 
     uds.fetchCaseDetails = function (caseNumber) {
-        var url =udsHostName.clone().setPath('/case/' + caseNumber);
-        return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath('/case/' + caseNumber);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.fetchCaseComments = function ( caseNumber) {
-        var url =udsHostName.clone().setPath('/case/' + caseNumber + "/comments");
-        return executeUdsAjaxCall(url,'GET');
+    uds.fetchCaseComments = function (caseNumber) {
+        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments");
+        return executeUdsAjaxCall(url, 'GET');
+    };
+
+    uds.fetchComments = function (uql) {
+        var url = udsHostName.clone().setPath('/case/comments').addQueryParam('where', uql);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.fetchCaseAssociateDetails = function (uql) {
-            var url =udsHostName.clone().setPath('/case/associates').addQueryParam('where', encodeURIComponent(uql));
-            return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath('/case/associates').addQueryParam('where', uql);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     //hold the lock on the case
     uds.getlock = function (caseNumber) {
-        var url =udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
-        return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
+        return executeUdsAjaxCall(url, 'GET');
     };
     //release the lock on the case
     uds.releaselock = function (caseNumber) {
-        var url =udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
-        return executeUdsAjaxCall(url,'DELETE');
+        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
+        return executeUdsAjaxCall(url, 'DELETE');
     };
 
     uds.fetchAccountDetails = function (accountNumber, resourceProjection) {
 
-        var url =udsHostName.clone().setPath('/account/' + accountNumber);
+        var url = udsHostName.clone().setPath('/account/' + accountNumber);
         if (resourceProjection != null) {
             url.addQueryParam('resourceProjection', resourceProjection);
         } else {
             url.addQueryParam('resourceProjection', 'Minimal');
         }
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.fetchAccountNotes = function (accountNumber) {
-        var url =udsHostName.clone().setPath('/account/' + accountNumber+'/notes');
-        return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath('/account/' + accountNumber + '/notes');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.fetchUserDetails = function (ssoUsername) {
-        var url =udsHostName.clone().setPath('/user/')+ssoUsername;
-        return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath('/user/') + ssoUsername;
+        return executeUdsAjaxCall(url, 'GET');
     };
     uds.fetchUser = function (userUql, resourceProjection) {
-        var url =udsHostName.clone().setPath('/user').addQueryParam('where', encodeURIComponent(userUql));
-        if(resourceProjection != null) {
+        var url = udsHostName.clone().setPath('/user').addQueryParam('where', userUql);
+        if (resourceProjection != null) {
             url.addQueryParam('resourceProjection', resourceProjection);
         }
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
     uds.fetchCases = function (uql, resourceProjection, limit, sortOption, statusOnly) {
         var path = '/case';
-        if(statusOnly){
+        if (statusOnly) {
             path = '/case/list-status-only'
         }
-        var url =udsHostName.clone().setPath(path).addQueryParam('where', encodeURIComponent(uql));
+        var url = udsHostName.clone().setPath(path).addQueryParam('where', uql);
         if (resourceProjection != null) {
             url.addQueryParam('resourceProjection', resourceProjection);
         } else {
@@ -155,292 +155,299 @@
         if (limit != null) {
             url.addQueryParam('limit', limit);
         }
-        if(sortOption != null){
-            url.addQueryParam('orderBy',sortOption);
+        if (sortOption != null) {
+            url.addQueryParam('orderBy', sortOption);
         }
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.generateBomgarSessionKey=function( caseId) {
-        var url =udsHostName.clone().setPath('/case/' + caseId + '/remote-session-key');
-        return executeUdsAjaxCall(url,'GET');
+    uds.generateBomgarSessionKey = function (caseId) {
+        var url = udsHostName.clone().setPath('/case/' + caseId + '/remote-session-key');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.postPublicComments = function (caseNumber,caseComment,hoursWorked) {
-        if(hoursWorked===undefined){
+    uds.postPublicComments = function (caseNumber, caseComment, hoursWorked) {
+        if (hoursWorked === undefined) {
             var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/public");
         } else {
-            var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/public/hoursWorked/"+hoursWorked);
+            var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/public/hoursWorked/" + hoursWorked);
         }
-        return executeUdsAjaxCallWithData(url,caseComment,'POST');
+        return executeUdsAjaxCallWithData(url, caseComment, 'POST');
     };
-    uds.postPrivateComments = function (caseNumber,caseComment,hoursWorked) {
+    uds.postPrivateComments = function (caseNumber, caseComment, hoursWorked) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/private");
-        if(hoursWorked===undefined){
+        if (hoursWorked === undefined) {
             var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/private");
         } else {
-            var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/private/hoursWorked/"+hoursWorked);
+            var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/private/hoursWorked/" + hoursWorked);
         }
-        return executeUdsAjaxCallWithData( url, caseComment,'POST');
+        return executeUdsAjaxCallWithData(url, caseComment, 'POST');
     };
-    uds.updateCaseDetails = function( caseNumber,caseDetails){
+    uds.updateCaseDetails = function (caseNumber, caseDetails) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber);
-        return executeUdsAjaxCallWithData(url, caseDetails,'PUT');
+        return executeUdsAjaxCallWithData(url, caseDetails, 'PUT');
     };
 
-    uds.fetchCaseHistory = function ( caseNumber) {
+    uds.fetchCaseHistory = function (caseNumber) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/history");
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.addAssociates = function (caseId,jsonAssociates) {
+    uds.addAssociates = function (caseId, jsonAssociates) {
         var url = udsHostName.clone().setPath('/case/' + caseId + "/associate");
-        return executeUdsAjaxCallWithData(url, jsonAssociates,'POST');
+        return executeUdsAjaxCallWithData(url, jsonAssociates, 'POST');
     };
 
     uds.getCQIQuestions = function (caseNumber) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + '/reviews/questions');
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.postCQIScore = function (caseNumber,reviewData) {
+    uds.postCQIScore = function (caseNumber, reviewData) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + '/reviews');
-        return executeUdsAjaxCallWithData(url,reviewData,'POST');
+        return executeUdsAjaxCallWithData(url, reviewData, 'POST');
     };
 
     uds.getSolutionDetails = function (solutionNumber, resourceProjection) {
         var url = udsHostName.clone().setPath('/documentation/solution/' + solutionNumber);
-        if(resourceProjection !== undefined) {url.addQueryParam('resourceProjection', resourceProjection);}
-        return executeUdsAjaxCall(url,'GET');
+        if (resourceProjection !== undefined) {
+            url.addQueryParam('resourceProjection', resourceProjection);
+        }
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.getSQIQuestions = function ( solutionNumber) {
+    uds.getSQIQuestions = function (solutionNumber) {
         var url = udsHostName.clone().setPath('/documentation/solution/' + solutionNumber + '/reviews/questions');
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.postSQIScore = function (solutionNumber,reviewData) {
+    uds.postSQIScore = function (solutionNumber, reviewData) {
         var url = udsHostName.clone().setPath('/documentation/solution/' + solutionNumber + '/reviews');
-        return executeUdsAjaxCallWithData(url,reviewData,'POST');
+        return executeUdsAjaxCallWithData(url, reviewData, 'POST');
     };
 
 
-    uds.getSbrList = function (resourceProjection,query) {
+    uds.getSbrList = function (resourceProjection, query) {
         var url = udsHostName.clone().setPath('/user/metadata/sbrs');
-        url.addQueryParam('resourceProjection',resourceProjection);
-        url.addQueryParam('where',encodeURIComponent(query));
-        return executeUdsAjaxCall(url,'GET');
+        url.addQueryParam('resourceProjection', resourceProjection);
+        url.addQueryParam('where', query);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.fetchCaseSbrs = function () {
-        var url =udsHostName.clone().setPath('/case/sbrs');
-        return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath('/case/sbrs');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.pinSolutionToCase = function( caseNumber,solutionJson){
+    uds.pinSolutionToCase = function (caseNumber, solutionJson) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber);
-        return executeUdsAjaxCallWithData(url, solutionJson ,'PUT');
+        return executeUdsAjaxCallWithData(url, solutionJson, 'PUT');
     };
 
     uds.removeUserSbr = function (userId, query) {
-        var url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', encodeURIComponent(query));
+        var url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', query);
         return executeUdsAjaxCall(url, 'DELETE');
     };
 
 
     uds.getRoleList = function (query) {
         var url = udsHostName.clone().setPath('/user/metadata/roles');
-        url.addQueryParam('where', encodeURIComponent(query));
-        return executeUdsAjaxCall( url, 'GET');
+        url.addQueryParam('where', query);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.getRoleDetails = function (roleId) {
-        var url = udsHostName.clone().setPath('/user/metadata/roles/'+roleId);
-        return executeUdsAjaxCall( url, 'GET');
+        var url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.removeUserRole = function (userId, query) {
-        var url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', encodeURIComponent(query));
+        var url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', query);
         return executeUdsAjaxCall(url, 'DELETE');
     };
 
-    uds.postAddUsersToSBR = function ( userId, uql, data) {
+    uds.postAddUsersToSBR = function (userId, uql, data) {
         if (uql == null || uql == undefined || uql === '') {
             throw 'User Query is mandatory';
         }
-        var url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', encodeURIComponent(uql));
+        var url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', uql);
         return executeUdsAjaxCallWithData(url, data, 'POST');
     };
 
-    uds.postAddUsersToRole = function ( userId, uql, data) {
+    uds.postAddUsersToRole = function (userId, uql, data) {
         if (uql == null || uql == undefined || uql === '') {
             throw 'User Query is mandatory';
         }
-        var url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', encodeURIComponent(uql));
-            return executeUdsAjaxCallWithData(url, data, 'POST');
+        var url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', uql);
+        return executeUdsAjaxCallWithData(url, data, 'POST');
     };
 
     uds.getOpenCasesForAccount = function (uql) {
         var path = '/case';
-        var url =udsHostName.clone().setPath(path).addQueryParam('where', encodeURIComponent(uql));
+        var url = udsHostName.clone().setPath(path).addQueryParam('where', uql);
         url.addQueryParam('resourceProjection', 'Minimal');
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.getCallLogsForCase = function (caseNumber) {
-        var url =udsHostName.clone().setPath('/case/' + caseNumber + "/calls");
-        return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/calls");
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     uds.getQuestionDependencies = function () {
         var path = '/case/ktquestions';
-        var url =udsHostName.clone().setPath(path);
-        return executeUdsAjaxCall(url,'GET');
+        var url = udsHostName.clone().setPath(path);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.postRoleLevel = function(userId,roleName,roleLevel) {
-        var url = udsHostName.clone().setPath('/user/' + userId + "/role-level/"+roleName);
-        return executeUdsAjaxCallWithData( url, roleLevel,'PUT');
+    uds.postRoleLevel = function (userId, roleName, roleLevel) {
+        var url = udsHostName.clone().setPath('/user/' + userId + "/role-level/" + roleName);
+        return executeUdsAjaxCallWithData(url, roleLevel, 'PUT');
     };
-    
-    uds.postEditPrivateComments = function (caseNumber,caseComment,caseCommentId,draft) {
-        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/"+ caseCommentId+"/private");
+
+    uds.postEditPrivateComments = function (caseNumber, caseComment, caseCommentId, draft) {
+        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/" + caseCommentId + "/private");
         url.addQueryParam('draft', draft);
-        return executeUdsAjaxCallWithData(url,caseComment,'PUT');
+        return executeUdsAjaxCallWithData(url, caseComment, 'PUT');
     };
 
-    uds.createCaseNep = function(caseNumber, nep) {
+    uds.createCaseNep = function (caseNumber, nep) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-        return executeUdsAjaxCallWithData( url, nep,'POST');
+        return executeUdsAjaxCallWithData(url, nep, 'POST');
     };
 
-    uds.updateCaseNep = function(caseNumber, nep) {
+    uds.updateCaseNep = function (caseNumber, nep) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-        return executeUdsAjaxCallWithData( url, nep,'PUT');
+        return executeUdsAjaxCallWithData(url, nep, 'PUT');
     };
 
-    uds.removeCaseNep = function(caseNumber) {
+    uds.removeCaseNep = function (caseNumber) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-        return executeUdsAjaxCall( url ,'DELETE');
+        return executeUdsAjaxCall(url, 'DELETE');
     };
 
-    uds.getAvgCSATForAccount = function(uql) {
-        var url = udsHostName.clone().setPath('/metrics/CsatAccountAvg').addQueryParam('where', encodeURIComponent(uql));
-        return executeUdsAjaxCall(url,'GET');
+    uds.getAvgCSATForAccount = function (uql) {
+        var url = udsHostName.clone().setPath('/metrics/CsatAccountAvg').addQueryParam('where', uql);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.getCaseContactsForAccount = function(accountNumber){
+    uds.getCaseContactsForAccount = function (accountNumber) {
         var url = udsHostName.clone().setPath('/account/' + accountNumber + "/contacts");
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.getCaseGroupsForContact = function(contactSSO){
+    uds.getCaseGroupsForContact = function (contactSSO) {
         var url = udsHostName.clone().setPath('/case/casegroups/user/' + contactSSO);
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.getRMECountForAccount = function(uql){
-        var url = udsHostName.clone().setPath('/case/history').addQueryParam('where', encodeURIComponent(uql));
-        return executeUdsAjaxCall(url,'GET');
+    uds.getRMECountForAccount = function (uql) {
+        var url = udsHostName.clone().setPath('/case/history').addQueryParam('where', uql);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.deleteAssociates = function(caseId,associateId){
+    uds.deleteAssociates = function (caseId, associateId) {
         var url = udsHostName.clone().setPath('/case/' + caseId + '/associate/' + associateId);
-        return executeUdsAjaxCall(url,'DELETE');
+        return executeUdsAjaxCall(url, 'DELETE');
     };
 
-    uds.updateCaseAssociate = function(caseId,jsonAssociates){
+    uds.updateCaseAssociate = function (caseId, jsonAssociates) {
         var url = udsHostName.clone().setPath('/case/' + caseId + "/associate");
-        return executeUdsAjaxCallWithData(url, jsonAssociates,'PUT');
+        return executeUdsAjaxCallWithData(url, jsonAssociates, 'PUT');
     };
 
-    uds.fetchSolutionDetails = function(solutionIdQuery){
-        var url = udsHostName.clone().setPath('/documentation/solution').addQueryParam('where', encodeURIComponent(solutionIdQuery));
+    uds.fetchSolutionDetails = function (solutionIdQuery) {
+        var url = udsHostName.clone().setPath('/documentation/solution').addQueryParam('where', solutionIdQuery);
         url.addQueryParam('resourceProjection', 'Minimal');
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.setHandlingSystem = function(caseNumber,handlingSystemArray){
+    uds.setHandlingSystem = function (caseNumber, handlingSystemArray) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/handlingsystems");
-        return executeUdsAjaxCallWithData(url, handlingSystemArray,'PUT');
+        return executeUdsAjaxCallWithData(url, handlingSystemArray, 'PUT');
     };
 
     uds.fetchSolr = function function_name(query) {
-      if(query.q === undefined || query.q === null || query.q === '') throw 'SOLR Query is mandatory';
+        if (query.q === undefined || query.q === null || query.q === '') throw 'SOLR Query is mandatory';
 
-      var url = udsHostName.clone().setPath('/solr');
-      url.addQueryParam('wt', 'json');
-      url.addQueryParam('q', query.q);
-      if(query.fq !== undefined && query.fq !== '') {
-        url.addQueryParam('fq', query.fq);
-      }
-      if(query.start !== undefined) {
-        url.addQueryParam('start', query.start);
-      }
-      if(query.rows !== undefined) {
-        url.addQueryParam('rows', query.rows);
-      }
-      if(query.sort !== undefined && query.sort !== '') {
-        url.addQueryParam('sort', query.sort);
-      }
+        var url = udsHostName.clone().setPath('/solr');
+        url.addQueryParam('wt', 'json');
+        url.addQueryParam('q', query.q);
+        if (query.fq !== undefined && query.fq !== '') {
+            url.addQueryParam('fq', query.fq);
+        }
+        if (query.start !== undefined) {
+            url.addQueryParam('start', query.start);
+        }
+        if (query.rows !== undefined) {
+            url.addQueryParam('rows', query.rows);
+        }
+        if (query.sort !== undefined && query.sort !== '') {
+            url.addQueryParam('sort', query.sort);
+        }
 
-      return executeUdsAjaxCall(url, 'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.addCaseSbrs = function(caseNumber,sbrArray){
+    uds.addCaseSbrs = function (caseNumber, sbrArray) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/sbrs");
-        return executeUdsAjaxCallWithData(url, sbrArray,'PUT');
+        return executeUdsAjaxCallWithData(url, sbrArray, 'PUT');
     };
 
-    uds.removeCaseSbrs = function(caseNumber,sbrArray){
+    uds.removeCaseSbrs = function (caseNumber, sbrArray) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/sbrs");
-        return executeUdsAjaxCallWithData(url, sbrArray,'DELETE');
+        return executeUdsAjaxCallWithData(url, sbrArray, 'DELETE');
     };
 
-    uds.getAllRolesList = function(query){
+    uds.getAllRolesList = function (query) {
         var url = udsHostName.clone().setPath('/user/metadata/roles/query');
-        url.addQueryParam('where', encodeURIComponent(query));
-        return executeUdsAjaxCall( url, 'GET');
+        url.addQueryParam('where', query);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.createRole = function(roleDetails){
+    uds.createRole = function (roleDetails) {
         var url = udsHostName.clone().setPath('/user/metadata/roles/add');
-        return executeUdsAjaxCallWithData(url, roleDetails,'POST');
+        return executeUdsAjaxCallWithData(url, roleDetails, 'POST');
     };
 
-    uds.updateRole = function(roleId,rolePayload){
-        var url = udsHostName.clone().setPath('/user/metadata/roles/'+roleId);
-        return executeUdsAjaxCallWithData(url, rolePayload,'PUT');
+    uds.updateRole = function (roleId, rolePayload) {
+        var url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
+        return executeUdsAjaxCallWithData(url, rolePayload, 'PUT');
     };
 
-    uds.deleteRole = function(roleId){
-        var url = udsHostName.clone().setPath('/user/metadata/roles/'+roleId);
-        return executeUdsAjaxCall(url,'DELETE');
+    uds.deleteRole = function (roleId) {
+        var url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
+        return executeUdsAjaxCall(url, 'DELETE');
     };
 
-    uds.getAdditionalContacts = function(caseNumber){
+    uds.getAdditionalContacts = function (caseNumber) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-        return executeUdsAjaxCall(url,'GET');
+        return executeUdsAjaxCall(url, 'GET');
     };
 
-    uds.removeAdditionalContacts = function(caseNumber,contacts){
+    uds.removeAdditionalContacts = function (caseNumber, contacts) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-        return executeUdsAjaxCallWithData(url,contacts,'DELETE');
+        return executeUdsAjaxCallWithData(url, contacts, 'DELETE');
     };
 
-    uds.addAdditionalContacts = function(caseNumber,contacts){
+    uds.addAdditionalContacts = function (caseNumber, contacts) {
         var url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-        return executeUdsAjaxCallWithData(url,contacts,'PUT');
+        return executeUdsAjaxCallWithData(url, contacts, 'PUT');
     };
 
-    uds.fetchBrmsSolrQuery = function(jsonObject){
+    uds.fetchBrmsSolrQuery = function (jsonObject) {
         var url = udsHostName.clone().setPath('/brms');
-        return executeUdsAjaxCallWithData(url, jsonObject,'POST');
+        return executeUdsAjaxCallWithData(url, jsonObject, 'POST');
     };
 
-    uds.fetchTopCasesFromSolr = function(queryString){
-        var url = udsHostName.clone().setPath('/solr?'+queryString);
-        return executeUdsAjaxCall(url,'GET');
+    uds.fetchTopCasesFromSolr = function (queryString) {
+        var url = udsHostName.clone().setPath('/solr?' + queryString);
+        return executeUdsAjaxCall(url, 'GET');
+    };
+    
+    uds.makeUqlQuery = function (path, uql) {
+        var url = udsHostName.clone().setPath(path).addQueryParam('where', uql);
+        return executeUdsAjaxCall(url, 'GET');
     };
 
     return uds;


### PR DESCRIPTION
Changes include:
- New endpoint for case comment range queries for Ascension Chatter
- Webstorm re-formatting to make the js style more consistent (This was automatic)
- Fixed the test cases so they run and pass, use https://prod.foo.redhat.com/test/index.html, the accessproxy, and python -m SimpleHTTPServer 8080 in the udsjs dir
- One major change was to upgrade jsuri to 1.3.1, everything that relies on udsjs must also use this version now.
- version bump to 1.2.29
