### PR TITLE
PCM-3027: Handle 204s for Firefox

### DIFF
--- a/dist/uds.js
+++ b/dist/uds.js
@@ -180,22 +180,39 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    var executeUdsAjaxCall = function executeUdsAjaxCall(url, httpMethod) {
-	        return Promise.resolve($.ajax($.extend({}, baseAjaxParams, {
-	            url: url,
-	            type: httpMethod,
-	            method: httpMethod
-	        })));
+	        return new Promise(function (resolve, reject) {
+	            return $.ajax($.extend({}, baseAjaxParams, {
+	                url: url,
+	                type: httpMethod,
+	                method: httpMethod,
+	                success: function success(response, status, xhr) {
+	                    return resolve(xhr.status === 204 ? null : response);
+	                },
+	                error: function error(xhr, status) {
+	                    return reject(xhr);
+	                }
+	            }));
+	        });
+	        return Promise.resolve();
 	    };
 
 	    var executeUdsAjaxCallWithData = function executeUdsAjaxCallWithData(url, data, httpMethod) {
-	        return Promise.resolve($.ajax($.extend({}, baseAjaxParams, {
-	            url: url,
-	            data: JSON.stringify(data),
-	            contentType: 'application/json',
-	            type: httpMethod,
-	            method: httpMethod,
-	            dataType: ''
-	        })));
+	        return new Promise(function (resolve, reject) {
+	            return $.ajax($.extend({}, baseAjaxParams, {
+	                url: url,
+	                data: JSON.stringify(data),
+	                contentType: 'application/json',
+	                type: httpMethod,
+	                method: httpMethod,
+	                dataType: '',
+	                success: function success(response, status, xhr) {
+	                    return resolve(xhr.status === 204 ? null : response);
+	                },
+	                error: function error(xhr, status) {
+	                    return reject(xhr);
+	                }
+	            }));
+	        });
 	    };
 
 	    function fetchCaseDetails(caseNumber) {

--- a/dist/uds.js
+++ b/dist/uds.js
@@ -196,7 +196,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return Promise.resolve();
 	    };
 
-	    var executeUdsAjaxCallWithData = function executeUdsAjaxCallWithData(url, data, httpMethod) {
+	    var executeUdsAjaxCallWithData = function executeUdsAjaxCallWithData(url, data, httpMethod, dataType) {
 	        return new Promise(function (resolve, reject) {
 	            return $.ajax($.extend({}, baseAjaxParams, {
 	                url: url,
@@ -204,7 +204,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                contentType: 'application/json',
 	                type: httpMethod,
 	                method: httpMethod,
-	                dataType: '',
+	                dataType: dataType || '',
 	                success: function success(response, status, xhr) {
 	                    return resolve(xhr.status === 204 ? null : response);
 	                },
@@ -588,7 +588,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    function getBrmsResponse(jsonObject) {
 	        var url = udsHostName.clone().setPath('/brms');
-	        return executeUdsAjaxCallWithData(url, jsonObject, 'POST');
+	        return executeUdsAjaxCallWithData(url, jsonObject, 'POST', 'text');
 	    }
 
 	    function fetchTopCasesFromSolr(queryString) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udsjs",
-  "version": "1.1.36",
+  "version": "1.1.37",
   "description": "Javascript library to interact with Unified Data Services",
   "main": "dist/uds.js",
   "directories": {

--- a/uds.js
+++ b/uds.js
@@ -44,22 +44,29 @@ const baseAjaxParams = {
 };
 
 const executeUdsAjaxCall = function (url, httpMethod) {
-    return Promise.resolve($.ajax($.extend({}, baseAjaxParams, {
-        url: url,
-        type: httpMethod,
-        method: httpMethod
+    return new Promise((resolve, reject) =>
+        $.ajax($.extend({}, baseAjaxParams, {
+            url: url,
+            type: httpMethod,
+            method: httpMethod,
+            success: (response, status, xhr) => resolve(xhr.status === 204 ? null : response),
+            error: (xhr, status) => reject(xhr)
     })));
+    return Promise.resolve();
 };
 
 const executeUdsAjaxCallWithData = function (url, data, httpMethod) {
-    return Promise.resolve($.ajax($.extend({}, baseAjaxParams, {
-        url: url,
-        data: JSON.stringify(data),
-        contentType: 'application/json',
-        type: httpMethod,
-        method: httpMethod,
-        dataType: ''
-    })));
+    return new Promise((resolve, reject) =>
+        $.ajax($.extend({}, baseAjaxParams, {
+            url: url,
+            data: JSON.stringify(data),
+            contentType: 'application/json',
+            type: httpMethod,
+            method: httpMethod,
+            dataType: '',
+            success: (response, status, xhr) => resolve(xhr.status === 204 ? null : response),
+            error: (xhr, status) => reject(xhr)
+        })));
 };
 
 export function fetchCaseDetails(caseNumber) {

--- a/uds.js
+++ b/uds.js
@@ -55,7 +55,7 @@ const executeUdsAjaxCall = function (url, httpMethod) {
     return Promise.resolve();
 };
 
-const executeUdsAjaxCallWithData = function (url, data, httpMethod) {
+const executeUdsAjaxCallWithData = function (url, data, httpMethod, dataType) {
     return new Promise((resolve, reject) =>
         $.ajax($.extend({}, baseAjaxParams, {
             url: url,
@@ -63,7 +63,7 @@ const executeUdsAjaxCallWithData = function (url, data, httpMethod) {
             contentType: 'application/json',
             type: httpMethod,
             method: httpMethod,
-            dataType: '',
+            dataType: dataType || '',
             success: (response, status, xhr) => resolve(xhr.status === 204 ? null : response),
             error: (xhr, status) => reject(xhr)
         })));
@@ -442,7 +442,7 @@ export function addAdditionalContacts (caseNumber, contacts) {
 
 export function getBrmsResponse (jsonObject) {
     const url = udsHostName.clone().setPath('/brms');
-    return executeUdsAjaxCallWithData(url, jsonObject, 'POST');
+    return executeUdsAjaxCallWithData(url, jsonObject, 'POST', 'text');
 }
 
 export function fetchTopCasesFromSolr (queryString) {


### PR DESCRIPTION
@vrathee @gandhikeyur @engineersamuel  Please review.
https://projects.engineering.redhat.com/browse/PCM-3027

Since there is a bug in FF which causes empty responses to be treated as XMLs. I added a check and if 204 is returned then I specifically return null instead of the response.

Note, this does not completely fix PCM-3027, I will do some fixes on Ascension side too. 
