### PR TITLE
PCM-5322: Wrapping all calls in checks for JWT expiry

### DIFF
--- a/dist/uds.js
+++ b/dist/uds.js
@@ -206,21 +206,77 @@ return /******/ (function(modules) { // webpackBootstrap
 	        dataType: ''
 	    };
 
+	    // If the token is expiring within 5 seconds, go ahead and refresh it.  Using 5 seconds as that is what keycloak uses as the default minValidity
+	    function isTokenExpired() {
+	        return window.sessionjs && window.sessionjs._state && window.sessionjs._state.keycloak && window.sessionjs._state.keycloak.isTokenExpired(5) === true;
+	    }
+
+	    function forceTokenRefresh() {
+	        console.warn('Udsjs detected the JWT token has expired, forcing an update');
+	        // -1 here forces the token to refresh
+	        return window.sessionjs._state.keycloak.updateToken(-1);
+	    }
+
+	    function getToken() {
+	        if (window.sessionjs && window.sessionjs._state.keycloak.token) {
+	            if (window.sessionjs.isAuthenticated()) {
+	                return 'Bearer ' + window.sessionjs._state.keycloak.token;
+	            } else {
+	                window.sessionjs.login();
+	            }
+	        }
+	        return '';
+	    }
+
 	    var executeUdsAjaxCall = function executeUdsAjaxCall(url, httpMethod) {
 	        return new Promise(function (resolve, reject) {
 	            return $.ajax($.extend({}, baseAjaxParams, {
 	                url: url,
 	                type: httpMethod,
 	                method: httpMethod,
+	                beforeSend: function beforeSend(xhr) {
+	                    if (getToken() !== '') {
+	                        xhr.setRequestHeader('Authorization', 'Bearer ' + getToken());
+	                    }
+	                },
 	                success: function success(response, status, xhr) {
 	                    return resolve(xhr.status === 204 ? null : response);
 	                },
-	                error: function error(xhr, status) {
+	                error: function error(xhr, status, errorThrown) {
 	                    return reject(xhr);
 	                }
 	            }));
 	        });
 	        return Promise.resolve();
+	    };
+
+	    var executeUdsAjaxCallWithJwt = function executeUdsAjaxCallWithJwt(url, httpMethod) {
+	        return new Promise(function (resolve, reject) {
+	            if (isTokenExpired()) {
+	                return forceTokenRefresh().success(function () {
+	                    executeUdsAjaxCall(url, httpMethod).then(function (response) {
+	                        return resolve(response);
+	                    }).catch(function (error) {
+	                        return reject(error);
+	                    });
+	                }).error(function () {
+	                    // Even if there was an error updating the token, we still need to hit udsjs, which at this point would probably return the "JWT expired" though this edge case is very unlikely.
+	                    console.warn('Udsjs unable to force an update of the JWT token.');
+	                    executeUdsAjaxCall(url, httpMethod).then(function (response) {
+	                        return resolve(response);
+	                    }).catch(function (error) {
+	                        return reject(error);
+	                    });
+	                });
+	            } else {
+	                // Else we have a valid token and continue as always.
+	                executeUdsAjaxCall(url, httpMethod).then(function (response) {
+	                    return resolve(response);
+	                }).catch(function (error) {
+	                    return reject(error);
+	                });
+	            }
+	        });
 	    };
 
 	    var executeUdsAjaxCallUnAuthed = function executeUdsAjaxCallUnAuthed(url, httpMethod) {
@@ -251,6 +307,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	                contentType: 'application/json',
 	                type: httpMethod,
 	                method: httpMethod,
+	                beforeSend: function beforeSend(xhr) {
+	                    // xhr.setRequestHeader('X-Omit', 'WWW-Authenticate');
+	                    if (window.sessionjs && window.sessionjs.isAuthenticated() && window.sessionjs._state.keycloak.token) {
+	                        xhr.setRequestHeader('Authorization', 'Bearer ' + window.sessionjs._state.keycloak.token);
+	                    }
+	                },
 	                dataType: dataType || '',
 	                success: function success(response, status, xhr) {
 	                    return resolve(xhr.status === 204 ? null : response);
@@ -262,36 +324,65 @@ return /******/ (function(modules) { // webpackBootstrap
 	        });
 	    };
 
+	    var executeUdsAjaxCallWithDataWithJwt = function executeUdsAjaxCallWithDataWithJwt(url, data, httpMethod, dataType) {
+	        return new Promise(function (resolve, reject) {
+	            if (isTokenExpired()) {
+	                return forceTokenRefresh().success(function () {
+	                    executeUdsAjaxCallWithData(url, data, httpMethod, dataType).then(function (response) {
+	                        return resolve(response);
+	                    }).catch(function (error) {
+	                        return reject(error);
+	                    });
+	                }).error(function () {
+	                    // Even if there was an error updating the token, we still need to hit udsjs, which at this point would probably return the "JWT expired" though this edge case is very unlikely.
+	                    console.warn('Udsjs unable to force an update of the JWT token.');
+	                    executeUdsAjaxCallWithData(url, data, httpMethod, dataType).then(function (response) {
+	                        return resolve(response);
+	                    }).catch(function (error) {
+	                        return reject(error);
+	                    });
+	                });
+	            } else {
+	                // Else we have a valid token and continue as always.
+	                executeUdsAjaxCallWithData(url, data, httpMethod, dataType).then(function (response) {
+	                    return resolve(response);
+	                }).catch(function (error) {
+	                    return reject(error);
+	                });
+	            }
+	        });
+	    };
+
 	    function fetchCaseDetails(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchCaseComments(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments");
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchComments(uql) {
 	        var url = udsHostName.clone().setPath('/case/comments').addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchCaseAssociateDetails(uql) {
 	        var url = udsHostName.clone().setPath('/case/associates').addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    //hold the lock on the case
 	    function getlock(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    //release the lock on the case
 	    function releaselock(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function fetchAccountDetails(accountNumber, resourceProjection) {
@@ -302,17 +393,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	        } else {
 	            url.addQueryParam('resourceProjection', 'Minimal');
 	        }
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchAccountNotes(accountNumber) {
 	        var url = udsHostName.clone().setPath('/account/' + accountNumber + '/notes');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchUserDetails(ssoUsername) {
 	        var url = udsHostName.clone().setPath('/user/') + ssoUsername;
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchUser(userUql, resourceProjection) {
@@ -320,7 +411,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (resourceProjection != null) {
 	            url.addQueryParam('resourceProjection', resourceProjection);
 	        }
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchCases(uql, resourceProjection, limit, sortOption, statusOnly, nepUql) {
@@ -343,12 +434,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (sortOption != null) {
 	            url.addQueryParam('orderBy', sortOption);
 	        }
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function generateBomgarSessionKey(caseId) {
 	        var url = udsHostName.clone().setPath('/case/' + caseId + '/remote-session-key');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function postPublicComments(caseNumber, caseComment, doNotChangeSbt, hoursWorked) {
@@ -359,7 +450,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (doNotChangeSbt) {
 	            url.addQueryParam('doNotChangeSbt', doNotChangeSbt);
 	        }
-	        return executeUdsAjaxCallWithData(url, caseComment, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'POST');
 	    }
 
 	    function postPrivateComments(caseNumber, caseComment, hoursWorked) {
@@ -369,38 +460,38 @@ return /******/ (function(modules) { // webpackBootstrap
 	        } else {
 	            url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/private/hoursWorked/" + hoursWorked);
 	        }
-	        return executeUdsAjaxCallWithData(url, caseComment, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'POST');
 	    }
 
 	    function updateCaseDetails(caseNumber, caseDetails) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber);
-	        return executeUdsAjaxCallWithData(url, caseDetails, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, caseDetails, 'PUT');
 	    }
 
 	    function updateCaseOwner(caseNumber, ownerSSO) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + '/owner/' + ownerSSO);
-	        return executeUdsAjaxCall(url, 'PUT');
+	        return executeUdsAjaxCallWithJwt(url, 'PUT');
 	    }
 
 	    function fetchCaseHistory(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/history");
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getCQIQuestions(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + '/reviews/questions');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    // Allows for UQL for fetching CQIs
 	    function getCQIs(uql) {
 	        var url = udsHostName.clone().setPath('/case/reviews').addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function postCQIScore(caseNumber, reviewData) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + '/reviews');
-	        return executeUdsAjaxCallWithData(url, reviewData, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, reviewData, 'POST');
 	    }
 
 	    function getSolutionDetails(solutionNumber, resourceProjection) {
@@ -408,35 +499,35 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (resourceProjection !== undefined) {
 	            url.addQueryParam('resourceProjection', resourceProjection);
 	        }
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getSQIQuestions(solutionNumber) {
 	        var url = udsHostName.clone().setPath('/documentation/solution/' + solutionNumber + '/reviews/questions');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    // Allows for UQL for fetching SQIs
 	    function getSQIs(uql) {
 	        var url = udsHostName.clone().setPath('/documentation/solution/reviews').addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function postSQIScore(solutionNumber, reviewData) {
 	        var url = udsHostName.clone().setPath('/documentation/solution/' + solutionNumber + '/reviews');
-	        return executeUdsAjaxCallWithData(url, reviewData, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, reviewData, 'POST');
 	    }
 
 	    function getSbrList(resourceProjection, query) {
 	        var url = udsHostName.clone().setPath('/user/metadata/sbrs');
 	        url.addQueryParam('resourceProjection', resourceProjection);
 	        url.addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchCaseSbrs() {
 	        var url = udsHostName.clone().setPath('/case/sbrs');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    // Unauthed sbrs
@@ -447,33 +538,33 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    function pinSolutionToCase(caseNumber, solutionJson) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber);
-	        return executeUdsAjaxCallWithData(url, solutionJson, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, solutionJson, 'PUT');
 	    }
 
 	    function removeUserSbr(userId, query) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function getRoleList(query) {
 	        var url = udsHostName.clone().setPath('/user/metadata/roles');
 	        url.addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getRoleDetails(roleId) {
 	        var url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function removeUserRole(userId, query) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function updateUserRole(userId, role) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/role/' + role.externalModelId);
-	        return executeUdsAjaxCallWithData(url, role.resource, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, role.resource, 'PUT');
 	    }
 
 	    function postAddUsersToSBR(userId, uql, data) {
@@ -481,7 +572,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            throw 'User Query is mandatory';
 	        }
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', uql);
-	        return executeUdsAjaxCallWithData(url, data, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, data, 'POST');
 	    }
 
 	    function postAddUsersToRole(userId, uql, data) {
@@ -489,103 +580,103 @@ return /******/ (function(modules) { // webpackBootstrap
 	            throw 'User Query is mandatory';
 	        }
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', uql);
-	        return executeUdsAjaxCallWithData(url, data, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, data, 'POST');
 	    }
 
 	    function getOpenCasesForAccount(uql) {
 	        var path = '/case';
 	        var url = udsHostName.clone().setPath(path).addQueryParam('where', uql);
 	        url.addQueryParam('resourceProjection', 'Minimal');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getCallLogsForCase(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/calls");
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getQuestionDependencies() {
 	        var path = '/case/ktquestions';
 	        var url = udsHostName.clone().setPath(path);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function postRoleLevel(userId, roleName, roleLevel) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + "/role-level/" + roleName);
-	        return executeUdsAjaxCallWithData(url, roleLevel, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, roleLevel, 'PUT');
 	    }
 
 	    function postEditPrivateComments(caseNumber, caseComment, caseCommentId, draft) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/" + caseCommentId + "/private");
 	        url.addQueryParam('draft', draft);
-	        return executeUdsAjaxCallWithData(url, caseComment, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'PUT');
 	    }
 
 	    function postPvtToPubComments(caseNumber, caseComment, caseCommentId, draft) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/" + caseCommentId + "/public");
 	        url.addQueryParam('draft', draft);
-	        return executeUdsAjaxCallWithData(url, caseComment, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'PUT');
 	    }
 
 	    function createCaseNep(caseNumber, nep) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-	        return executeUdsAjaxCallWithData(url, nep, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, nep, 'POST');
 	    }
 
 	    function updateCaseNep(caseNumber, nep) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-	        return executeUdsAjaxCallWithData(url, nep, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, nep, 'PUT');
 	    }
 
 	    function removeCaseNep(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function getAvgCSATForAccount(uql) {
 	        var url = udsHostName.clone().setPath('/metrics/CsatAccountAvg').addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getCaseContactsForAccount(accountNumber) {
 	        var url = udsHostName.clone().setPath('/account/' + accountNumber + "/contacts");
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getCaseGroupsForContact(contactSSO) {
 	        var url = udsHostName.clone().setPath('/case/casegroups/user/' + contactSSO);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getRMECountForAccount(uql) {
 	        var url = udsHostName.clone().setPath('/case/history').addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function addAssociates(caseNumber, jsonAssociates) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/associate");
-	        return executeUdsAjaxCallWithData(url, jsonAssociates, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, jsonAssociates, 'POST');
 	    }
 
 	    function deleteAssociates(caseNumber, jsonAssociates) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/associate");
-	        return executeUdsAjaxCallWithData(url, jsonAssociates, 'DELETE');
+	        return executeUdsAjaxCallWithDataWithJwt(url, jsonAssociates, 'DELETE');
 	    }
 
 	    function fetchSolutionDetails(solutionIdQuery) {
 	        var url = udsHostName.clone().setPath('/documentation/solution').addQueryParam('where', solutionIdQuery);
 	        url.addQueryParam('resourceProjection', 'Minimal');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function setHandlingSystem(caseNumber, handlingSystemArray) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/handlingsystems");
-	        return executeUdsAjaxCallWithData(url, handlingSystemArray, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, handlingSystemArray, 'PUT');
 	    }
 
 	    function fetchKCSFromDrupal(id) {
 	        var url = udsHostName.clone().setPath('/documentation/drupalapi/' + id);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchSolr(query) {
@@ -610,7 +701,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            url.addQueryParam('fl', query.fl);
 	        }
 
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchCaseSolr(query) {
@@ -635,182 +726,182 @@ return /******/ (function(modules) { // webpackBootstrap
 	            url.addQueryParam('fl', query.fl);
 	        }
 
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function addCaseSbrs(caseNumber, sbrArray) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/sbrs");
-	        return executeUdsAjaxCallWithData(url, sbrArray, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, sbrArray, 'PUT');
 	    }
 
 	    function removeCaseSbrs(caseNumber, sbrArray) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/sbrs");
-	        return executeUdsAjaxCallWithData(url, sbrArray, 'DELETE');
+	        return executeUdsAjaxCallWithDataWithJwt(url, sbrArray, 'DELETE');
 	    }
 
 	    function getAllRolesList(query) {
 	        var url = udsHostName.clone().setPath('/user/metadata/roles/query');
 	        url.addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function createRole(roleDetails) {
 	        var url = udsHostName.clone().setPath('/user/metadata/roles/add');
-	        return executeUdsAjaxCallWithData(url, roleDetails, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, roleDetails, 'POST');
 	    }
 
 	    function updateRole(roleId, rolePayload) {
 	        var url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
-	        return executeUdsAjaxCallWithData(url, rolePayload, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, rolePayload, 'PUT');
 	    }
 
 	    function deleteRole(roleId) {
 	        var url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function getAdditionalContacts(caseNumber) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function removeAdditionalContacts(caseNumber, contacts) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-	        return executeUdsAjaxCallWithData(url, contacts, 'DELETE');
+	        return executeUdsAjaxCallWithDataWithJwt(url, contacts, 'DELETE');
 	    }
 
 	    function addAdditionalContacts(caseNumber, contacts) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-	        return executeUdsAjaxCallWithData(url, contacts, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, contacts, 'PUT');
 	    }
 
 	    function getBrmsResponse(jsonObject) {
 	        var url = udsHostName.clone().setPath('/brms');
-	        return executeUdsAjaxCallWithData(url, jsonObject, 'POST', 'text');
+	        return executeUdsAjaxCallWithDataWithJwt(url, jsonObject, 'POST', 'text');
 	    }
 
 	    function fetchTopCasesFromSolr(queryString) {
 	        var url = udsHostName.clone().setPath('/solr?' + queryString);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getUserDetailsFromSFDC(userID) {
 	        var url = udsHostName.clone().setPath('/salesforce/user/' + userID);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function updateUserDetailsInSFDC(ssoUsername, data) {
 	        var url = udsHostName.clone().setPath('/user/salesforce/' + ssoUsername);
-	        return executeUdsAjaxCallWithData(url, data, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, data, 'PUT');
 	    }
 
 	    function getCallCenterFromSFDC(callCenterId) {
 	        var url = udsHostName.clone().setPath('/callcenter/' + callCenterId);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function getCaseTagsList() {
 	        var url = udsHostName.clone().setPath('/case/tags');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function addCaseTags(caseNumber, tagsArray) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/tags");
-	        return executeUdsAjaxCallWithData(url, tagsArray, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, tagsArray, 'PUT');
 	    }
 
 	    function removeCaseTags(caseNumber, tagsArray) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + "/tags");
-	        return executeUdsAjaxCallWithData(url, tagsArray, 'DELETE');
+	        return executeUdsAjaxCallWithDataWithJwt(url, tagsArray, 'DELETE');
 	    }
 
 	    function fetchPriorityTemplates(uql) {
 	        var url = udsHostName.clone().setPath('/user/metadata/templates');
 	        url.addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchCaseLanguages() {
 	        var url = udsHostName.clone().setPath('/case/languages');
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchBugzillas(uql) {
 	        var url = udsHostName.clone().setPath('/bug');
 	        url.addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function fetchBugzillaComments(uql) {
 	        var url = udsHostName.clone().setPath('/bug/comments');
 	        url.addQueryParam('where', uql);
-	        return executeUdsAjaxCall(url, 'GET');
+	        return executeUdsAjaxCallWithJwt(url, 'GET');
 	    }
 
 	    function addLanguageToUser(userId, language, type) {
 	        if (type !== "primary" && type !== "secondary") type = "primary";
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/language/' + type + '/' + language);
-	        return executeUdsAjaxCall(url, 'POST');
+	        return executeUdsAjaxCallWithJwt(url, 'POST');
 	    }
 
 	    function removeLanguagesFromUser(userId, query) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/language').addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function addTagToUser(userId, tagName) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/tag/' + tagName);
-	        return executeUdsAjaxCall(url, 'POST');
+	        return executeUdsAjaxCallWithJwt(url, 'POST');
 	    }
 
 	    function removeTagsFromUser(userId, query) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/tag').addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function addUserAsQB(qbUserId, userId) {
 	        var url = udsHostName.clone().setPath('/user/' + qbUserId + '/queuebuddy/' + userId);
-	        return executeUdsAjaxCall(url, 'POST');
+	        return executeUdsAjaxCallWithJwt(url, 'POST');
 	    }
 
 	    function removeUserQBs(qbUserId, query) {
 	        var url = udsHostName.clone().setPath('/user/' + qbUserId + '/queuebuddy').addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function addNNOToUser(userId, nnoRegion) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/nnoregion/' + nnoRegion);
-	        return executeUdsAjaxCall(url, 'POST');
+	        return executeUdsAjaxCallWithJwt(url, 'POST');
 	    }
 
 	    function removeNNOsFromUser(userId, query) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/nnoregion').addQueryParam('where', query);
-	        return executeUdsAjaxCall(url, 'DELETE');
+	        return executeUdsAjaxCallWithJwt(url, 'DELETE');
 	    }
 
 	    function setGbdSuperRegion(userId, value) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/virtualoffice/' + value);
-	        return executeUdsAjaxCall(url, 'PUT');
+	        return executeUdsAjaxCallWithJwt(url, 'PUT');
 	    }
 
 	    function setOutOfOfficeflag(userId, value) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/out-of-office');
-	        return executeUdsAjaxCallWithData(url, value, 'POST');
+	        return executeUdsAjaxCallWithDataWithJwt(url, value, 'POST');
 	    }
 
 	    function updateResourceLink(caseNumber, resourceLink) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + '/resourcelink');
-	        return executeUdsAjaxCallWithData(url, resourceLink, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, resourceLink, 'PUT');
 	    }
 
 	    function updateNightShiftForUser(userId, value) {
 	        var url = udsHostName.clone().setPath('/user/' + userId + '/nightshift/' + value);
-	        return executeUdsAjaxCall(url, 'PUT');
+	        return executeUdsAjaxCallWithJwt(url, 'PUT');
 	    }
 
 	    function updateCaseAttachment(caseNumber, attachmentId, attachmentDetails) {
 	        var url = udsHostName.clone().setPath('/case/' + caseNumber + '/attachment/' + attachmentId);
-	        return executeUdsAjaxCallWithData(url, attachmentDetails, 'PUT');
+	        return executeUdsAjaxCallWithDataWithJwt(url, attachmentDetails, 'PUT');
 	    }
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udsjs",
-  "version": "1.1.61",
+  "version": "1.1.62",
   "description": "Javascript library to interact with Unified Data Services",
   "main": "dist/uds.js",
   "directories": {

--- a/uds.js
+++ b/uds.js
@@ -45,6 +45,28 @@ const baseAjaxParams = {
     dataType: ''
 };
 
+// If the token is expiring within 5 seconds, go ahead and refresh it.  Using 5 seconds as that is what keycloak uses as the default minValidity
+function isTokenExpired() {
+    return (window.sessionjs && window.sessionjs._state && window.sessionjs._state.keycloak && window.sessionjs._state.keycloak.isTokenExpired(5) === true);
+}
+
+function forceTokenRefresh() {
+    console.warn(`Udsjs detected the JWT token has expired, forcing an update`);
+    // -1 here forces the token to refresh
+    return window.sessionjs._state.keycloak.updateToken(-1);
+}
+
+function getToken() {
+    if (window.sessionjs && window.sessionjs._state.keycloak.token) {
+        if (window.sessionjs.isAuthenticated()) {
+            return `Bearer ${window.sessionjs._state.keycloak.token}`;
+        } else {
+            window.sessionjs.login();
+        }
+    }
+    return '';
+}
+
 const executeUdsAjaxCall = function (url, httpMethod) {
     return new Promise((resolve, reject) =>
         $.ajax($.extend({}, baseAjaxParams, {
@@ -52,15 +74,31 @@ const executeUdsAjaxCall = function (url, httpMethod) {
             type: httpMethod,
             method: httpMethod,
             beforeSend: function(xhr) {
-                // xhr.setRequestHeader('X-Omit', 'WWW-Authenticate');
-                if(window.sessionjs && window.sessionjs.isAuthenticated() && window.sessionjs._state.keycloak.token) {
-                    xhr.setRequestHeader('Authorization', 'Bearer ' + window.sessionjs._state.keycloak.token);
+                if(getToken() !== '') {
+                    xhr.setRequestHeader('Authorization', 'Bearer ' + getToken());
                 }
             },
             success: (response, status, xhr) => resolve(xhr.status === 204 ? null : response),
-            error: (xhr, status) => reject(xhr)
+            error: (xhr, status, errorThrown) => reject(xhr)
         })));
     return Promise.resolve();
+};
+
+const executeUdsAjaxCallWithJwt = function (url, httpMethod) {
+    return new Promise((resolve, reject) => {
+        if (isTokenExpired()) {
+            return forceTokenRefresh().success(() => {
+                executeUdsAjaxCall(url, httpMethod).then((response) => resolve(response)).catch((error) => reject(error));
+            }).error(() => {
+                // Even if there was an error updating the token, we still need to hit udsjs, which at this point would probably return the "JWT expired" though this edge case is very unlikely.
+                console.warn(`Udsjs unable to force an update of the JWT token.`);
+                executeUdsAjaxCall(url, httpMethod).then((response) => resolve(response)).catch((error) => reject(error));
+            });
+        } else {
+            // Else we have a valid token and continue as always.
+            executeUdsAjaxCall(url, httpMethod).then((response) => resolve(response)).catch((error) => reject(error));
+        }
+    });
 };
 
 const executeUdsAjaxCallUnAuthed = function (url, httpMethod) {
@@ -98,36 +136,53 @@ const executeUdsAjaxCallWithData = function (url, data, httpMethod, dataType) {
         })));
 };
 
+const executeUdsAjaxCallWithDataWithJwt = function (url, data, httpMethod, dataType) {
+    return new Promise((resolve, reject) => {
+        if (isTokenExpired()) {
+            return forceTokenRefresh().success(() => {
+                executeUdsAjaxCallWithData(url, data, httpMethod, dataType).then((response) => resolve(response)).catch((error) => reject(error));
+            }).error(() => {
+                // Even if there was an error updating the token, we still need to hit udsjs, which at this point would probably return the "JWT expired" though this edge case is very unlikely.
+                console.warn(`Udsjs unable to force an update of the JWT token.`);
+                executeUdsAjaxCallWithData(url, data, httpMethod, dataType).then((response) => resolve(response)).catch((error) => reject(error));
+            });
+        } else {
+            // Else we have a valid token and continue as always.
+            executeUdsAjaxCallWithData(url, data, httpMethod, dataType).then((response) => resolve(response)).catch((error) => reject(error));
+        }
+    });
+};
+
 export function fetchCaseDetails(caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchCaseComments(caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments");
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchComments(uql) {
     const url = udsHostName.clone().setPath('/case/comments').addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchCaseAssociateDetails(uql) {
     const url = udsHostName.clone().setPath('/case/associates').addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 //hold the lock on the case
 export function getlock (caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 //release the lock on the case
 export function releaselock (caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/lock");
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function fetchAccountDetails (accountNumber, resourceProjection) {
@@ -138,17 +193,17 @@ export function fetchAccountDetails (accountNumber, resourceProjection) {
     } else {
         url.addQueryParam('resourceProjection', 'Minimal');
     }
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchAccountNotes (accountNumber) {
     const url = udsHostName.clone().setPath('/account/' + accountNumber + '/notes');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchUserDetails (ssoUsername) {
     const url = udsHostName.clone().setPath('/user/') + ssoUsername;
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchUser (userUql, resourceProjection) {
@@ -156,7 +211,7 @@ export function fetchUser (userUql, resourceProjection) {
     if (resourceProjection != null) {
         url.addQueryParam('resourceProjection', resourceProjection);
     }
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchCases (uql, resourceProjection, limit, sortOption, statusOnly, nepUql) {
@@ -179,12 +234,12 @@ export function fetchCases (uql, resourceProjection, limit, sortOption, statusOn
     if (sortOption != null) {
         url.addQueryParam('orderBy', sortOption);
     }
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function generateBomgarSessionKey (caseId) {
     const url = udsHostName.clone().setPath('/case/' + caseId + '/remote-session-key');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function postPublicComments (caseNumber, caseComment, doNotChangeSbt, hoursWorked) {
@@ -195,7 +250,7 @@ export function postPublicComments (caseNumber, caseComment, doNotChangeSbt, hou
     if (doNotChangeSbt) {
         url.addQueryParam('doNotChangeSbt', doNotChangeSbt);
     }
-    return executeUdsAjaxCallWithData(url, caseComment, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'POST');
 }
 
 export function postPrivateComments (caseNumber, caseComment, hoursWorked) {
@@ -205,38 +260,38 @@ export function postPrivateComments (caseNumber, caseComment, hoursWorked) {
     } else {
         url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/private/hoursWorked/" + hoursWorked);
     }
-    return executeUdsAjaxCallWithData(url, caseComment, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'POST');
 }
 
 export function updateCaseDetails (caseNumber, caseDetails) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber);
-    return executeUdsAjaxCallWithData(url, caseDetails, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, caseDetails, 'PUT');
 }
 
 export function updateCaseOwner(caseNumber, ownerSSO) {
     const url = udsHostName.clone().setPath(`/case/${caseNumber}/owner/${ownerSSO}`);
-    return executeUdsAjaxCall(url, 'PUT');
+    return executeUdsAjaxCallWithJwt(url, 'PUT');
 }
 
 export function fetchCaseHistory (caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/history");
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getCQIQuestions (caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + '/reviews/questions');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 // Allows for UQL for fetching CQIs
 export function getCQIs(uql) {
     const url = udsHostName.clone().setPath('/case/reviews').addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function postCQIScore (caseNumber, reviewData) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + '/reviews');
-    return executeUdsAjaxCallWithData(url, reviewData, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, reviewData, 'POST');
 }
 
 export function getSolutionDetails (solutionNumber, resourceProjection) {
@@ -244,35 +299,35 @@ export function getSolutionDetails (solutionNumber, resourceProjection) {
     if (resourceProjection !== undefined) {
         url.addQueryParam('resourceProjection', resourceProjection);
     }
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getSQIQuestions (solutionNumber) {
     const url = udsHostName.clone().setPath('/documentation/solution/' + solutionNumber + '/reviews/questions');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 // Allows for UQL for fetching SQIs
 export function getSQIs(uql) {
     const url = udsHostName.clone().setPath('/documentation/solution/reviews').addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function postSQIScore (solutionNumber, reviewData) {
     const url = udsHostName.clone().setPath('/documentation/solution/' + solutionNumber + '/reviews');
-    return executeUdsAjaxCallWithData(url, reviewData, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, reviewData, 'POST');
 }
 
 export function getSbrList (resourceProjection, query) {
     let url = udsHostName.clone().setPath('/user/metadata/sbrs');
     url.addQueryParam('resourceProjection', resourceProjection);
     url.addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchCaseSbrs () {
     const url = udsHostName.clone().setPath('/case/sbrs');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 // Unauthed sbrs
@@ -283,33 +338,33 @@ export function fetchCaseSbrsExternal () {
 
 export function pinSolutionToCase (caseNumber, solutionJson) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber);
-    return executeUdsAjaxCallWithData(url, solutionJson, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, solutionJson, 'PUT');
 }
 
 export function removeUserSbr (userId, query) {
     const url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function getRoleList (query) {
     let url = udsHostName.clone().setPath('/user/metadata/roles');
     url.addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getRoleDetails (roleId) {
     const url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function removeUserRole (userId, query) {
     const url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function updateUserRole(userId, role) {
     const url = udsHostName.clone().setPath(`/user/${userId}/role/${role.externalModelId}`);
-    return executeUdsAjaxCallWithData(url, role.resource, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, role.resource, 'PUT');
 }
 
 export function postAddUsersToSBR (userId, uql, data) {
@@ -317,7 +372,7 @@ export function postAddUsersToSBR (userId, uql, data) {
         throw 'User Query is mandatory';
     }
     const url = udsHostName.clone().setPath('/user/' + userId + '/sbr').addQueryParam('where', uql);
-    return executeUdsAjaxCallWithData(url, data, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, data, 'POST');
 }
 
 export function postAddUsersToRole (userId, uql, data) {
@@ -325,103 +380,103 @@ export function postAddUsersToRole (userId, uql, data) {
         throw 'User Query is mandatory';
     }
     const url = udsHostName.clone().setPath('/user/' + userId + '/role').addQueryParam('where', uql);
-    return executeUdsAjaxCallWithData(url, data, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, data, 'POST');
 }
 
 export function getOpenCasesForAccount (uql) {
     const path = '/case';
     let url = udsHostName.clone().setPath(path).addQueryParam('where', uql);
     url.addQueryParam('resourceProjection', 'Minimal');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getCallLogsForCase (caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/calls");
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getQuestionDependencies () {
     const path = '/case/ktquestions';
     const url = udsHostName.clone().setPath(path);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function postRoleLevel (userId, roleName, roleLevel) {
     const url = udsHostName.clone().setPath('/user/' + userId + "/role-level/" + roleName);
-    return executeUdsAjaxCallWithData(url, roleLevel, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, roleLevel, 'PUT');
 }
 
 export function postEditPrivateComments (caseNumber, caseComment, caseCommentId, draft) {
     let url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/" + caseCommentId + "/private");
     url.addQueryParam('draft', draft);
-    return executeUdsAjaxCallWithData(url, caseComment, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'PUT');
 }
 
 export function postPvtToPubComments(caseNumber, caseComment, caseCommentId, draft) {
     var url = udsHostName.clone().setPath('/case/' + caseNumber + "/comments/" + caseCommentId + "/public");
     url.addQueryParam('draft', draft);
-    return executeUdsAjaxCallWithData(url, caseComment, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, caseComment, 'PUT');
 }
 
 export function createCaseNep (caseNumber, nep) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-    return executeUdsAjaxCallWithData(url, nep, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, nep, 'POST');
 }
 
 export function updateCaseNep (caseNumber, nep) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-    return executeUdsAjaxCallWithData(url, nep, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, nep, 'PUT');
 }
 
 export function removeCaseNep (caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/nep");
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function getAvgCSATForAccount (uql) {
     const url = udsHostName.clone().setPath('/metrics/CsatAccountAvg').addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getCaseContactsForAccount (accountNumber) {
     const url = udsHostName.clone().setPath('/account/' + accountNumber + "/contacts");
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getCaseGroupsForContact (contactSSO) {
     const url = udsHostName.clone().setPath('/case/casegroups/user/' + contactSSO);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getRMECountForAccount (uql) {
     const url = udsHostName.clone().setPath('/case/history').addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function addAssociates (caseNumber, jsonAssociates) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/associate");
-    return executeUdsAjaxCallWithData(url, jsonAssociates, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, jsonAssociates, 'POST');
 }
 
 export function deleteAssociates (caseNumber, jsonAssociates) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/associate");
-    return executeUdsAjaxCallWithData(url, jsonAssociates, 'DELETE');
+    return executeUdsAjaxCallWithDataWithJwt(url, jsonAssociates, 'DELETE');
 }
 
 export function fetchSolutionDetails (solutionIdQuery) {
     let url = udsHostName.clone().setPath('/documentation/solution').addQueryParam('where', solutionIdQuery);
     url.addQueryParam('resourceProjection', 'Minimal');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function setHandlingSystem (caseNumber, handlingSystemArray) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/handlingsystems");
-    return executeUdsAjaxCallWithData(url, handlingSystemArray, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, handlingSystemArray, 'PUT');
 }
 
 export function fetchKCSFromDrupal(id) {
     const url = udsHostName.clone().setPath('/documentation/drupalapi/' + id);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchSolr (query) {
@@ -446,7 +501,7 @@ export function fetchSolr (query) {
         url.addQueryParam('fl', query.fl);
     }
 
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchCaseSolr(query) {
@@ -471,185 +526,185 @@ export function fetchCaseSolr(query) {
         url.addQueryParam('fl', query.fl);
     }
 
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function addCaseSbrs (caseNumber, sbrArray) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/sbrs");
-    return executeUdsAjaxCallWithData(url, sbrArray, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, sbrArray, 'PUT');
 }
 
 export function removeCaseSbrs (caseNumber, sbrArray) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/sbrs");
-    return executeUdsAjaxCallWithData(url, sbrArray, 'DELETE');
+    return executeUdsAjaxCallWithDataWithJwt(url, sbrArray, 'DELETE');
 }
 
 export function getAllRolesList (query) {
     let url = udsHostName.clone().setPath('/user/metadata/roles/query');
     url.addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function createRole (roleDetails) {
     const url = udsHostName.clone().setPath('/user/metadata/roles/add');
-    return executeUdsAjaxCallWithData(url, roleDetails, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, roleDetails, 'POST');
 }
 
 export function updateRole (roleId, rolePayload) {
     const url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
-    return executeUdsAjaxCallWithData(url, rolePayload, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, rolePayload, 'PUT');
 }
 
 export function deleteRole (roleId) {
     const url = udsHostName.clone().setPath('/user/metadata/roles/' + roleId);
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function getAdditionalContacts (caseNumber) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function removeAdditionalContacts (caseNumber, contacts) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-    return executeUdsAjaxCallWithData(url, contacts, 'DELETE');
+    return executeUdsAjaxCallWithDataWithJwt(url, contacts, 'DELETE');
 }
 
 export function addAdditionalContacts (caseNumber, contacts) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/contacts");
-    return executeUdsAjaxCallWithData(url, contacts, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, contacts, 'PUT');
 }
 
 export function getBrmsResponse (jsonObject) {
     const url = udsHostName.clone().setPath('/brms');
-    return executeUdsAjaxCallWithData(url, jsonObject, 'POST', 'text');
+    return executeUdsAjaxCallWithDataWithJwt(url, jsonObject, 'POST', 'text');
 }
 
 export function fetchTopCasesFromSolr (queryString) {
     const url = udsHostName.clone().setPath('/solr?' + queryString);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getUserDetailsFromSFDC (userID) {
     const url = udsHostName.clone().setPath('/salesforce/user/' + userID);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function updateUserDetailsInSFDC(ssoUsername,data) {
     const url = udsHostName.clone().setPath('/user/salesforce/'+ssoUsername);
-    return executeUdsAjaxCallWithData(url, data, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, data, 'PUT');
 }
 
 export function getCallCenterFromSFDC (callCenterId) {
     const url = udsHostName.clone().setPath('/callcenter/' + callCenterId);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function getCaseTagsList () {
     const url = udsHostName.clone().setPath('/case/tags');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function addCaseTags (caseNumber, tagsArray) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/tags");
-    return executeUdsAjaxCallWithData(url, tagsArray, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, tagsArray, 'PUT');
 }
 
 export function removeCaseTags (caseNumber, tagsArray) {
     const url = udsHostName.clone().setPath('/case/' + caseNumber + "/tags");
-    return executeUdsAjaxCallWithData(url, tagsArray, 'DELETE');
+    return executeUdsAjaxCallWithDataWithJwt(url, tagsArray, 'DELETE');
 }
 
 export function fetchPriorityTemplates(uql) {
     const url = udsHostName.clone().setPath('/user/metadata/templates');
     url.addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchCaseLanguages() {
     const url = udsHostName.clone().setPath('/case/languages');
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchBugzillas(uql) {
     const url = udsHostName.clone().setPath('/bug');
     url.addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 export function fetchBugzillaComments(uql) {
     const url = udsHostName.clone().setPath('/bug/comments');
     url.addQueryParam('where', uql);
-    return executeUdsAjaxCall(url, 'GET');
+    return executeUdsAjaxCallWithJwt(url, 'GET');
 }
 
 
 export function addLanguageToUser(userId, language, type) {
     if(type !== "primary" && type !== "secondary") type = "primary";
     const url = udsHostName.clone().setPath(`/user/${userId}/language/${type}/${language}`);
-    return executeUdsAjaxCall(url, 'POST');
+    return executeUdsAjaxCallWithJwt(url, 'POST');
 }
 
 export function removeLanguagesFromUser(userId, query) {
     const url = udsHostName.clone().setPath(`/user/${userId}/language`)
         .addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function addTagToUser(userId, tagName) {
     const url = udsHostName.clone().setPath(`/user/${userId}/tag/${tagName}`);
-    return executeUdsAjaxCall(url, 'POST');
+    return executeUdsAjaxCallWithJwt(url, 'POST');
 }
 
 export function removeTagsFromUser(userId, query) {
     const url = udsHostName.clone().setPath(`/user/${userId}/tag`)
         .addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function addUserAsQB(qbUserId, userId) {
     const url = udsHostName.clone().setPath(`/user/${qbUserId}/queuebuddy/${userId}`);
-    return executeUdsAjaxCall(url, 'POST');
+    return executeUdsAjaxCallWithJwt(url, 'POST');
 }
 
 export function removeUserQBs(qbUserId, query) {
     const url = udsHostName.clone().setPath(`/user/${qbUserId}/queuebuddy`)
         .addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function addNNOToUser(userId, nnoRegion) {
     const url = udsHostName.clone().setPath(`/user/${userId}/nnoregion/${nnoRegion}`);
-    return executeUdsAjaxCall(url, 'POST');
+    return executeUdsAjaxCallWithJwt(url, 'POST');
 }
 
 export function removeNNOsFromUser(userId, query) {
     const url = udsHostName.clone().setPath(`/user/${userId}/nnoregion`)
         .addQueryParam('where', query);
-    return executeUdsAjaxCall(url, 'DELETE');
+    return executeUdsAjaxCallWithJwt(url, 'DELETE');
 }
 
 export function setGbdSuperRegion(userId, value) {
     const url = udsHostName.clone().setPath(`/user/${userId}/virtualoffice/${value}`);
-    return executeUdsAjaxCall(url, 'PUT');
+    return executeUdsAjaxCallWithJwt(url, 'PUT');
 }
 
 export function setOutOfOfficeflag(userId, value) {
     const url = udsHostName.clone().setPath(`/user/${userId}/out-of-office`);
-    return executeUdsAjaxCallWithData(url, value, 'POST');
+    return executeUdsAjaxCallWithDataWithJwt(url, value, 'POST');
 }
 
 export function updateResourceLink(caseNumber, resourceLink) {
     const url = udsHostName.clone().setPath(`/case/${caseNumber}/resourcelink`);
-    return executeUdsAjaxCallWithData(url, resourceLink, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, resourceLink, 'PUT');
 }
 
 export function updateNightShiftForUser(userId, value) {
     const url = udsHostName.clone().setPath(`/user/${userId}/nightshift/${value}`);
-    return executeUdsAjaxCall(url, 'PUT');
+    return executeUdsAjaxCallWithJwt(url, 'PUT');
 }
 
 export function updateCaseAttachment(caseNumber, attachmentId, attachmentDetails) {
     const url = udsHostName.clone().setPath(`/case/${caseNumber}/attachment/${attachmentId}`);
-    return executeUdsAjaxCallWithData(url, attachmentDetails, 'PUT');
+    return executeUdsAjaxCallWithDataWithJwt(url, attachmentDetails, 'PUT');
 }


### PR DESCRIPTION
Each call to UDS should first check that the token is valid, if not, force a refresh of the token before continuing.